### PR TITLE
Add mcp Stdio client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,102 @@
 # ModelContextProtocolClient
+
+A Spring Boot client application that demonstrates different transport methods (WebFlux SSE, Stdio) for communicating with the MCP server.
+
+## Setup
+
+1. Create a `.env` file in the root directory with your API keys:
+```bash
+BRAVE_SEARCH_API_KEY=your_brave_search_api_key_here
+WEATHER_API_KEY=your_weather_api_key_here
+```
+
+2. Clone https://github.com/InnoBridge/ModelContextProtocolServer
+
+3. Docker Setup
+   1. Update volume mappings in docker-compose.yml:
+   ```yaml
+    modelcontextprotocolclient_application
+    ...
+   volumes:
+     - .:/app
+     - /var/run/docker.sock:/var/run/docker.sock
+     - ./local/root:/root
+     - ../{path to ModelContextProtocolServer repo}:/ModelContextProtocolServer
+   ```
+
+   2. Start the Docker containers:
+   ```bash
+   sudo docker compose up
+   ```
+
+   3. Build and run the mcp server:
+   ```bash
+   # In a new terminal
+   sudo docker exec -it modelcontextprotocolserver-application sh
+   cd /app
+   ./mvnw clean install
+   ./mvnw spring-boot:run
+   ```
+
+   4. Build and run the client:
+   ```bash
+   # In another new terminal
+   docker exec -it modelcontextprotocolclient-application sh
+   ./mvnw spring-boot:run
+   ```
+
+## Available Endpoints
+
+### WebFlux Transport
+
+- `GET /webflux/tools` - List all available tools
+- `POST /webflux/calculate` - Calculate using the calculator tool
+  ```bash
+  curl -X POST "http://localhost:8080/webflux/calculate?operation=add&a=5&b=3"
+  ```
+- `POST /webflux/weather` - Get weather information
+  ```bash
+  curl -X POST "http://localhost:8080/webflux/weather?location=San%20Francisco&format=celsius"
+  ```
+
+### Stdio Transport
+
+- `GET /stdio/tools` - List all available tools
+- `POST /stdio/calculate` - Calculate using the calculator tool
+  ```bash
+  curl -X POST "http://localhost:8080/stdio/calculate?operation=add&a=5&b=3"
+  ```
+- `POST /stdio/weather` - Get weather information
+  ```bash
+  curl -X POST "http://localhost:8080/stdio/weather?location=San%20Francisco&format=celsius"
+  ```
+
+### BraveSearch Transport
+
+- `GET /tools/bravesearch` - List available tools
+- `POST /bravesearch` - Perform a web search
+  ```bash
+  curl -X POST "http://localhost:8080/bravesearch?query=spring%20boot"
+  ```
+
+## Configuration
+
+The application supports multiple transport configurations:
+
+1. WebFlux SSE Transport (default)
+   - Communicates with the server using Server-Sent Events
+   - Server must be running in WebFlux mode
+
+2. Stdio Transport
+   - Communicates with the server using standard input/output
+   - Automatically launches the server jar in stdio mode
+
+3. BraveSearch Transport
+   - Communicates with the BraveSearch API
+   - Requires `BRAVE_SEARCH_API_KEY` in `.env` file
+   - Get your API key from [Brave Search API](https://brave.com/search/api/)
+
+4. Weather API
+   - Used by both WebFlux and Stdio transports for weather information
+   - Requires `WEATHER_API_KEY` in `.env` file
+   - Get your API key from [WeatherAPI](https://www.weatherapi.com/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - .:/app
       - /var/run/docker.sock:/var/run/docker.sock
       - ./local/root:/root
-      # - ../ModelContextProtocolClient:/ModelContextProtocolClient # Use for local development
+      - ../ModelContextProtocolServer:/ModelContextProtocolServer # Use for local development
  # Use entrypoint instead of command to ensure the container keeps running
     entrypoint: >
       bash -c "


### PR DESCRIPTION
This pull request introduces significant enhancements to the `ModelContextProtocolClient` project, including new transport methods, additional endpoints, and updated configurations. The most important changes are summarized below:

### Documentation and Setup:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R102): Added comprehensive setup instructions, including creating a `.env` file for API keys, cloning the server repository, Docker setup, and running both the server and client applications. Detailed information on available endpoints and configuration options for different transports (WebFlux, Stdio, BraveSearch, Weather API) is also included.

### Docker Configuration:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L22-R22): Updated volume mappings to correctly reference the `ModelContextProtocolServer` repository for local development.

### Configuration Enhancements:
* [`src/main/java/io/github/innobridge/mcpclient/configuration/McpConfiguration.java`](diffhunk://#diff-f9aa2d94b24cc204ecd914faf5003af425c2fa6f64544b2472f4bceaddd13785R82-R106): Added methods to create `McpSyncClient` and `ClientMcpTransport` beans for the Stdio MCP Server, enabling support for Stdio transport mode. [[1]](diffhunk://#diff-f9aa2d94b24cc204ecd914faf5003af425c2fa6f64544b2472f4bceaddd13785R82-R106) [[2]](diffhunk://#diff-f9aa2d94b24cc204ecd914faf5003af425c2fa6f64544b2472f4bceaddd13785R119-R144)

### Controller Updates:
* [`src/main/java/io/github/innobridge/mcpclient/controller/McpController.java`](diffhunk://#diff-508f858e794085d3be21d53441d6c99792b7ed24e71b974e1a28a2a14e7ea95dR39-R42): Introduced new endpoints for the Stdio transport, including `/stdio/tools`, `/stdio/calculate`, and `/stdio/weather`, to list tools, perform calculations, and get weather information, respectively. Updated existing endpoints to include WebFlux-specific paths. [[1]](diffhunk://#diff-508f858e794085d3be21d53441d6c99792b7ed24e71b974e1a28a2a14e7ea95dR39-R42) [[2]](diffhunk://#diff-508f858e794085d3be21d53441d6c99792b7ed24e71b974e1a28a2a14e7ea95dR55-R67) [[3]](diffhunk://#diff-508f858e794085d3be21d53441d6c99792b7ed24e71b974e1a28a2a14e7ea95dL82-R101) [[4]](diffhunk://#diff-508f858e794085d3be21d53441d6c99792b7ed24e71b974e1a28a2a14e7ea95dL106-R149) [[5]](diffhunk://#diff-508f858e794085d3be21d53441d6c99792b7ed24e71b974e1a28a2a14e7ea95dR168-R189)